### PR TITLE
Questions fixes

### DIFF
--- a/IDP-lets-go/Scenarios/ScenarioView.swift
+++ b/IDP-lets-go/Scenarios/ScenarioView.swift
@@ -123,14 +123,18 @@ struct SelectableButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .frame(width: 50, height: 30)
-            .background(Color.clear)
+            .background(
+                RoundedRectangle(cornerRadius: 50)
+                    .fill(isSelected ? Color.mainBlue : Color.clear)
+            )
             .overlay(
                 RoundedRectangle(cornerRadius: 50)
                     .stroke(isSelected ? Color.mainBlue : Color.gray.opacity(0.5), lineWidth: 2)
             )
-            .foregroundColor(.primary)
+            .foregroundColor(isSelected ? .white : .primary)
     }
 }
+
     
 
 #Preview {


### PR DESCRIPTION
- button and title is moved to navbar in the questions
- the selected options are shown: the button style is changed to a transparent one with a blue outline for the selected ones
- you cannot move forward if you haven't selected one option for both least and most
- only one option can be selected for least and most